### PR TITLE
Disabled sys.err redirection for now

### DIFF
--- a/src/main/java/com/github/tcn/plexi/gui/MainView.java
+++ b/src/main/java/com/github/tcn/plexi/gui/MainView.java
@@ -50,7 +50,7 @@ public class MainView extends JFrame {
         setIconImages(icons);
 
         //set system output
-        System.setErr(guiOut);
+        //System.setErr(guiOut); //Disabled for now to bypass issue on certain platforms 
         System.setOut(guiOut);
 
 


### PR DESCRIPTION
redirecting sys.out on mac os crashes the application. I can't quite figure out why, (I cant seem to catch the exception), so I'm disabling it for now since we dont write to that anyway.
