### PR TITLE
Better errors

### DIFF
--- a/src/main/java/com/github/tcn/plexi/Settings.java
+++ b/src/main/java/com/github/tcn/plexi/Settings.java
@@ -13,10 +13,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Properties;
+import java.util.*;
 
 
 /**
@@ -41,7 +38,8 @@ public class Settings {
     private String overseerrUrl = null; //URL to the overseerr api plexi should use for media
     private String overseerrKey = null; //Key to the overseerr api
     private String ownerId = null; //ID of the discord user who is running the bot
-    private Boolean usersViewRequests = null; //Lets users view overseerr requests if set to true.
+    private Boolean usersViewRequests; //Lets users view overseerr requests if set to true.
+    private Boolean sendErrorReports; //If enabled, plexi will send the owner of the bot a message when it encounters a command error
 
 
     //Versioning information - pulled from /resources/assets/comithash.txt (hopefully)
@@ -130,9 +128,8 @@ public class Settings {
             prefix = properties.getProperty("prefix").replaceAll("^\"|\"$", "");
             overseerrUrl = properties.getProperty("overseerrURL").replaceAll("^\"|\"$", "");
             overseerrKey = properties.getProperty("overseerrKey").replaceAll("^\"|\"$", "");
-
-            //this one is a bit special because we need to cast it to a boolean - this value defaults to false if an invalid value is provided
             usersViewRequests = Boolean.valueOf(properties.getProperty("usersViewRequests").replaceAll("^\"|\"$", "").toLowerCase());
+            sendErrorReports = Boolean.valueOf(properties.getProperty("generateErrorReports").replaceAll("^\"|\"$", "").toLowerCase(Locale.ROOT));
 
             if (!validateSettings()) {
                 JOptionPane.showMessageDialog(null, "The config file contains invalid settings, please check it and try again.", "Plexi - Configuration Issue", JOptionPane.INFORMATION_MESSAGE);
@@ -295,6 +292,9 @@ public class Settings {
         if(usersViewRequests == null){
             isValid = false;
         }
+        if(sendErrorReports == null){
+            isValid = false;
+        }
 
         //ping the overseerr API to see if we have valid settings
         //if this throws an exception, we have invalid values
@@ -376,5 +376,9 @@ public class Settings {
 
     public String getOverseerrKey(){
         return overseerrKey;
+    }
+
+    public Boolean sendErrorReports(){
+        return sendErrorReports;
     }
 }

--- a/src/main/java/com/github/tcn/plexi/discordBot/commands/SearchCommand.java
+++ b/src/main/java/com/github/tcn/plexi/discordBot/commands/SearchCommand.java
@@ -5,7 +5,7 @@ import com.github.tcn.plexi.discordBot.eventHandlers.ButtonManager;
 import com.github.tcn.plexi.discordBot.paginators.searchPaginator.SearchPaginator;
 import com.github.tcn.plexi.overseerr.OverseerApiCaller;
 import com.github.tcn.plexi.overseerr.templates.search.MediaSearch;
-import com.github.tcn.plexi.utils.Misc;
+import com.github.tcn.plexi.utils.MiscUtils;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.User;
@@ -41,18 +41,17 @@ public class SearchCommand extends CommandTemplate {
 
     @Override
     public void executeTextCommand(User author, TextChannel channel, Message message, String content, GuildMessageReceivedEvent event) {
-
         MediaSearch results;
         //lets determine if the user specified a media type
         String[] args = content.split(" ", 2);
         if(args[0].toLowerCase().matches("tv|television|telly|tele|t") && args.length == 2){
             LoggerFactory.getLogger("Plexi: SearchCommand").info("Searching for: \"" + args[1] + "\" in movies");
             results = new OverseerApiCaller().Search(args[1]);
-            Misc.filterByType(results, "tv");
+            MiscUtils.filterByType(results, "tv");
         }else if(args[0].toLowerCase().matches("movie|film|feature|flick|cinematic|cine|movies|films|features|flicks|m") && args.length == 2){
             LoggerFactory.getLogger("Plexi: SearchCommand").info("Searching for: \"" + args[1] + "\" in tv");
             results = new OverseerApiCaller().Search(args[1]);
-            Misc.filterByType(results, "movie");
+            MiscUtils.filterByType(results, "movie");
         }else{
             LoggerFactory.getLogger("Plexi: SearchCommand").info("Searching for: \"" + content + "\" in any media type");
             results = new OverseerApiCaller().Search(content);
@@ -77,7 +76,6 @@ public class SearchCommand extends CommandTemplate {
 
     @Override
     public void executeSlashCommand(SlashCommandEvent event) {
-
         //first lets acknowledge the command before discord gets all grumpy about it
         event.deferReply().setEphemeral(false).queue();
 
@@ -86,7 +84,7 @@ public class SearchCommand extends CommandTemplate {
 
         //filter the search results if requested
         if(event.getOptions().size() == 2){
-            Misc.filterByType(results, event.getOptions().get(1).getAsString());
+            MiscUtils.filterByType(results, event.getOptions().get(1).getAsString());
             LoggerFactory.getLogger("Plexi: SearchCommand").info("Searching for: \"" + event.getOptions().get(0).getAsString() + "\" in " + event.getOptions().get(1).getAsString());
         }else{
             LoggerFactory.getLogger("Plexi: SearchCommand").info("Searching for: \"" + event.getOptions().get(0).getAsString() + "\" in any media type");
@@ -106,9 +104,6 @@ public class SearchCommand extends CommandTemplate {
         }else{
             event.getHook().editOriginal("No results found for the query: \""+event.getOptions().get(0).getAsString()+"\"").queue();
         }
-
-
-
 
     }
 

--- a/src/main/java/com/github/tcn/plexi/discordBot/commands/ViewRequestsCommand.java
+++ b/src/main/java/com/github/tcn/plexi/discordBot/commands/ViewRequestsCommand.java
@@ -5,7 +5,7 @@ import com.github.tcn.plexi.discordBot.eventHandlers.ButtonManager;
 import com.github.tcn.plexi.discordBot.paginators.RequestsPaginator;
 import com.github.tcn.plexi.overseerr.OverseerApiCaller;
 import com.github.tcn.plexi.overseerr.templates.request.allRequests.MediaRequests;
-import com.github.tcn.plexi.utils.Misc;
+import com.github.tcn.plexi.utils.MiscUtils;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.User;
@@ -138,9 +138,9 @@ public class ViewRequestsCommand extends CommandTemplate{
 
         //filter the media type if set to something other than all
         if(mediaType.matches("movie|film|feature|flick|cinematic|cine|movies|films|features|flicks|m")){
-            Misc.filterByType(requests, "movie");
+            MiscUtils.filterByType(requests, "movie");
         }else if(mediaType.matches("tv|television|telly|tele|t")){
-            Misc.filterByType(requests, "tv");
+            MiscUtils.filterByType(requests, "tv");
         }
 
 

--- a/src/main/java/com/github/tcn/plexi/discordBot/eventHandlers/CommandHandler.java
+++ b/src/main/java/com/github/tcn/plexi/discordBot/eventHandlers/CommandHandler.java
@@ -37,16 +37,16 @@ public class CommandHandler extends ListenerAdapter {
         LoggerFactory.getLogger("Plexi: Commands").info("loaded " + commandSet.size() + " commands!");
 
         //now we need to register the slash commands
-        List<CommandData> test = new ArrayList<>();
+        List<CommandData> commandList = new ArrayList<>();
         for(CommandTemplate command : commandSet){
             if(command.getSlashCommand() != null){
-                test.add(command.getSlashCommand());
+                commandList.add(command.getSlashCommand());
             }
         }
-        DiscordBot.getInstance().getJDAInstance().updateCommands().addCommands(test).queue();
+        DiscordBot.getInstance().getJDAInstance().updateCommands().addCommands(commandList).queue();
 
         //Log Slash Command Loading
-        LoggerFactory.getLogger("Plexi: Commands").info("loaded " + test.size() + " Slash Commands!");
+        LoggerFactory.getLogger("Plexi: Commands").info("loaded " + commandList.size() + " Slash Commands!");
     }
 
 
@@ -122,7 +122,10 @@ public class CommandHandler extends ListenerAdapter {
                 final String content = stripPrefix(alias, prefix, message);
                 template.executeTextCommand(event.getAuthor(), event.getChannel(), event.getMessage(),content, event);
             }catch (final Exception e){
-                LoggerFactory.getLogger("Plexi: CommandHandler").error("Unable to handle \"" +alias +"\" chat command! " + e.getLocalizedMessage() );
+                LoggerFactory.getLogger("Plexi: CommandHandler").error("Unable to handle \"" +alias +"\" chat command! " + e.getLocalizedMessage());
+
+                //Along with that message, we should inform the person running the bot of this issue and how to report it if neccessary
+                event.getMessage().reply("Sorry, I was unable to finish executing that command. Please try again later").queue();
             }
         });
     }
@@ -133,6 +136,11 @@ public class CommandHandler extends ListenerAdapter {
                 template.executeSlashCommand(event);
             }catch (Exception e){
                 LoggerFactory.getLogger("Plexi: CommandHandler").error("Unable to handle \"" + event.getName() +"\" slash command! " + e.getLocalizedMessage() );
+                if(!event.isAcknowledged()){
+                    event.reply("Sorry, I was unable to finish executing that command. Please try again later.").queue();
+                }else{
+                    event.getHook().editOriginal("Sorry, I was unable to finish executing that command. Please try again later.").setActionRows().setEmbeds().queue();
+                }
             }
         });
     }

--- a/src/main/java/com/github/tcn/plexi/discordBot/paginators/searchPaginator/SearchPaginator.java
+++ b/src/main/java/com/github/tcn/plexi/discordBot/paginators/searchPaginator/SearchPaginator.java
@@ -5,7 +5,7 @@ import com.github.tcn.plexi.discordBot.EmbedManager;
 import com.github.tcn.plexi.discordBot.paginators.Paginator;
 import com.github.tcn.plexi.overseerr.templates.search.MediaSearch;
 import com.github.tcn.plexi.overseerr.templates.search.Result;
-import com.github.tcn.plexi.utils.Misc;
+import com.github.tcn.plexi.utils.MiscUtils;
 import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
@@ -135,7 +135,7 @@ public class SearchPaginator extends Paginator {
                 throw new IllegalArgumentException("Cannot build, invalid arguments!");
             }
             //strip out the people from the search result
-            Misc.stripActors(searchResults);
+            MiscUtils.stripActors(searchResults);
             //calculate the number of pages
             numOfPages = searchResults.getResults().size();
             return new SearchPaginator(this.MESSAGE, this.EVENT, this.USER_ID, this.numOfPages, this.WRAP, this.searchResults, this.BUTTON_MANAGER);

--- a/src/main/java/com/github/tcn/plexi/utils/MiscUtils.java
+++ b/src/main/java/com/github/tcn/plexi/utils/MiscUtils.java
@@ -12,7 +12,7 @@ import java.util.concurrent.ThreadFactory;
 
 
 //a class full of random static methods for things
-public class Misc {
+public class MiscUtils {
 
     public static ThreadFactory newThreadFactory(String threadName, Logger logger, boolean isDaemon){
         return (r) ->{
@@ -50,6 +50,14 @@ public class Misc {
     public static MediaRequests filterByType(MediaRequests requests, String filter){
         requests.getResults().removeIf(request -> !request.getType().equals(filter));
         return requests;
+    }
+
+    public static String formatStackTraceAsString(StackTraceElement[] stackTrace){
+        StringBuilder stackTraceString = new StringBuilder();
+        for(StackTraceElement stackElement: stackTrace){
+            stackTraceString.append(stackElement.toString()).append("\n");
+        }
+        return stackTraceString.toString();
     }
 
 

--- a/src/main/resources/assets/config.txt
+++ b/src/main/resources/assets/config.txt
@@ -35,4 +35,8 @@ overseerrKey = "KEY_HERE"
 //Allow users other than the bot owner to view media requests (default is true)
 usersViewRequests = "true"
 
+//If true, Plexi will send the user with the above 'Owner ID' a detailed error message if a command fails to execute.
+//This information is NOT sent to anybody else and mainly serves as a debugging/bug finding tool to allow users to report to our github repo
+generateErrorReports = "true/false"
+
 //end of config


### PR DESCRIPTION
This makes Plexi inform the discord user if there is an error. Some things are still not caught and require more work, but in general things should fail a lot more gracefully. 

In addition to that, a new option in the config file allows Plexi to send the owner of the bot (the one put in the config file, not me) a full error report. This should make it easier to find the error and gives users everything they need to file a bug report.